### PR TITLE
Add illustration to the docs site

### DIFF
--- a/docs/src/imgs/intro_illustration.svg
+++ b/docs/src/imgs/intro_illustration.svg
@@ -1,0 +1,407 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="337.83246mm"
+   height="129.40916mm"
+   viewBox="0 0 337.83246 129.40916"
+   version="1.1"
+   id="svg890"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="intro_illustration.svg">
+  <defs
+     id="defs884">
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path9903"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9903-4"
+         style="fill:#0002ff;fill-opacity:1;fill-rule:evenodd;stroke:#0002ff;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-8-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9903-4-3"
+         style="fill:#00be41;fill-opacity:1;fill-rule:evenodd;stroke:#00be41;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9903-0"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-8-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9903-4-32"
+         style="fill:#0002ff;fill-opacity:1;fill-rule:evenodd;stroke:#0002ff;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-8-0-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9903-4-3-6"
+         style="fill:#00be42;fill-opacity:1;fill-rule:evenodd;stroke:#00be42;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="1110.0325"
+     inkscape:cy="186.40803"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2556"
+     inkscape:window-height="1327"
+     inkscape:window-x="1920"
+     inkscape:window-y="88"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata887">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(72.251036,-3.5440162)">
+    <flowRoot
+       xml:space="preserve"
+       id="flowRoot24721"
+       style="font-style:normal;font-weight:normal;font-size:21.33333397px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       transform="matrix(0.26458333,0,0,0.26458333,-76.729209,-3.1750001)"><flowRegion
+         id="flowRegion24723"><rect
+           id="rect24725"
+           width="202.85715"
+           height="35.714287"
+           x="172.85715"
+           y="563.23395" /></flowRegion><flowPara
+         id="flowPara24727" /></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="flowRoot5440"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       transform="matrix(0.26458333,0,0,0.26458333,-76.729209,-3.1750001)"><flowRegion
+         id="flowRegion5442"><rect
+           id="rect5444"
+           width="832.14288"
+           height="467.85715"
+           x="-47.857143"
+           y="-3.9088864" /></flowRegion><flowPara
+         id="flowPara5446"></flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="flowRoot5448"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       transform="matrix(0.26458333,0,0,0.26458333,-76.729209,-3.1750001)"><flowRegion
+         id="flowRegion5450"><rect
+           id="rect5452"
+           width="12.142858"
+           height="57.142857"
+           x="231.42857"
+           y="312.51968" /></flowRegion><flowPara
+         id="flowPara5454"></flowPara></flowRoot>    <flowRoot
+       xml:space="preserve"
+       id="flowRoot5456"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       transform="matrix(0.26458333,0,0,0.26458333,-76.729209,-3.1750001)"><flowRegion
+         id="flowRegion5458"><rect
+           id="rect5460"
+           width="826.42859"
+           height="492.14285"
+           x="-37.142857"
+           y="-3.9088864" /></flowRegion><flowPara
+         id="flowPara5462"></flowPara></flowRoot>    <g
+       id="g6767"
+       transform="translate(32.111468,12.290003)">
+      <rect
+         transform="matrix(1,0,-0.62194133,0.78306384,0,0)"
+         y="82.980865"
+         x="85.730881"
+         height="47.303509"
+         width="86.506126"
+         id="rect5300"
+         style="fill:#d7ac4d;fill-opacity:0.34827588;stroke:#000000;stroke-width:0.43596309;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         transform="matrix(0.97683735,-0.21398316,-0.56326383,0.82627711,0,0)"
+         y="47.292038"
+         x="69.317047"
+         height="40.880219"
+         width="85.352768"
+         id="rect5300-3"
+         style="fill:#d7794d;fill-opacity:0.34827588;stroke:#000000;stroke-width:0.40257332;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <text
+         transform="rotate(-12.318604)"
+         id="text13648"
+         y="30.937965"
+         x="36.890907"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';fill:#646464;fill-opacity:1;stroke-width:0.26458332"
+           y="30.937965"
+           x="36.890907"
+           id="tspan13646"
+           sodipodi:role="line">xy-plane of child coordinate frame</tspan></text>
+      <text
+         id="text13648-4"
+         y="106.50747"
+         x="5.2752857"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';fill:#646464;fill-opacity:1;stroke-width:0.26458332"
+           y="106.50747"
+           x="5.2752857"
+           id="tspan13646-7"
+           sodipodi:role="line">xy-plane of parent coordinate frame</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path13720"
+         d="M 39.725232,82.082737 H 52.48186"
+         style="fill:none;stroke:#ff0000;stroke-width:0.86500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13720-5"
+         d="m 39.725232,82.082737 9.976656,-7.362224"
+         style="fill:none;stroke:#0002ff;stroke-width:0.86500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-8)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13720-5-6"
+         d="m 39.725232,82.082737 0.32502,-10.895604"
+         style="fill:none;stroke:#00be41;stroke-width:0.86500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-8-0)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path13720-1"
+         d="M 86.971995,35.213689 99.187796,31.538643"
+         style="fill:none;stroke:#ff0000;stroke-width:0.86500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-1)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13720-5-5"
+         d="m 86.971995,35.213689 7.432738,-9.924264"
+         style="fill:none;stroke:#0002ff;stroke-width:0.86500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-8-6)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path13720-5-6-5"
+         d="M 86.971995,35.213689 84.14436,24.686378"
+         style="fill:none;stroke:#00be42;stroke-width:0.86500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Mend-8-0-0)" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path18509"
+         d="m 39.725232,82.082737 h 37.32494 l 9.827323,-8.882439"
+         style="fill:none;stroke:#000000;stroke-width:0.565;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.25999988, 2.25999988;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text18730"
+         y="86.618454"
+         x="59.7202"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';stroke-width:0.26458332"
+           y="86.618454"
+           x="59.7202"
+           id="tspan18728"
+           sodipodi:role="line">x</tspan></text>
+      <text
+         id="text18730-4"
+         y="80.791321"
+         x="83.801559"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';stroke-width:0.26458332"
+           y="80.791321"
+           x="83.801559"
+           id="tspan18728-7"
+           sodipodi:role="line">y</tspan><tspan
+           id="tspan18750"
+           style="stroke-width:0.26458332"
+           y="87.846878"
+           x="83.801559"
+           sodipodi:role="line" /></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path380"
+         d="M 86.877495,73.200296 V 35.213689 h 0.0945 v 0"
+         style="fill:none;stroke:#000000;stroke-width:0.565;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.25999988, 2.25999988;stroke-dashoffset:0;stroke-opacity:1" />
+      <text
+         id="text18730-4-3"
+         y="54.69088"
+         x="87.948265"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';stroke-width:0.26458332"
+           y="54.69088"
+           x="87.948265"
+           id="tspan18728-7-6"
+           sodipodi:role="line">z</tspan><tspan
+           id="tspan18750-7"
+           style="stroke-width:0.26458332"
+           y="61.746437"
+           x="87.948265"
+           sodipodi:role="line" /></text>
+      <text
+         id="text18730-5"
+         y="87.292511"
+         x="49.783356"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#ff0000;fill-opacity:1;stroke-width:0.26458332"
+           y="87.292511"
+           x="49.783356"
+           id="tspan18728-3"
+           sodipodi:role="line">x̂</tspan></text>
+      <text
+         id="text18730-5-5"
+         y="76.198547"
+         x="51.249756"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#0000ff;fill-opacity:1;stroke-width:0.26458332"
+           y="76.198547"
+           x="51.249756"
+           id="tspan18728-3-6"
+           sodipodi:role="line">ŷ</tspan></text>
+      <text
+         id="text18730-5-5-2"
+         y="71.09317"
+         x="36.884895"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.86500001;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00be00;fill-opacity:1;stroke-width:0.86500001;stroke-miterlimit:4;stroke-dasharray:none"
+           y="71.09317"
+           x="36.884895"
+           id="tspan18728-3-6-9"
+           sodipodi:role="line">ẑ</tspan></text>
+      <text
+         id="text18730-5-1"
+         y="36.859634"
+         x="96.783287"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#ff0000;fill-opacity:1;stroke-width:0.26458332"
+           y="36.859634"
+           x="96.783287"
+           id="tspan18728-3-2"
+           sodipodi:role="line"><tspan
+   id="tspan5685"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif">R</tspan>x̂</tspan></text>
+      <text
+         id="text18730-5-5-7"
+         y="26.332636"
+         x="95.414879"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#0000ff;fill-opacity:1;stroke-width:0.26458332"
+           y="26.332636"
+           x="95.414879"
+           id="tspan18728-3-6-0"
+           sodipodi:role="line"><tspan
+   id="tspan5687"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif">R</tspan>ŷ</tspan></text>
+      <text
+         id="text18730-5-5-2-9"
+         y="25.007023"
+         x="78.403946"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.86500001;stroke-miterlimit:4;stroke-dasharray:none"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#00be00;fill-opacity:1;stroke-width:0.86500001;stroke-miterlimit:4;stroke-dasharray:none"
+           y="25.007023"
+           x="78.403946"
+           id="tspan18728-3-6-9-3"
+           sodipodi:role="line"><tspan
+   id="tspan5689"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#00be00;fill-opacity:1;stroke-width:0.86500001;stroke-miterlimit:4;stroke-dasharray:none">R</tspan>ẑ</tspan></text>
+    </g>
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#c8c8c8;stroke-width:0.49543458;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+       id="rect6436"
+       width="337.33704"
+       height="128.91373"
+       x="-72.003319"
+       y="3.7917335"
+       ry="0" />
+  </g>
+</svg>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,9 @@ CurrentModule = PoseComposition
 
 ---
 
+![Illustration of Pose geometry](imgs/intro_illustration.svg)
+
+
 PoseComposition.jl is a library for representing and manipulating poses.  It
 places particular emphasis on:
 


### PR DESCRIPTION
A much needed intro figure to give the reader a visual of what geometric transformation we're talking about.

Based on the graphic design of [this](https://github.com/probcomp/neurips2021-3d-tex/blob/76ff84593fcf619948412c357c25065042bd4872/paper_figures/edges.svg) figure by @nishadgothoskar.

## Tested
Docs site looks good locally.