### PR TITLE
Fix numerics issue

### DIFF
--- a/src/PoseComposition.jl
+++ b/src/PoseComposition.jl
@@ -294,8 +294,14 @@ interp(a::Pose, b::Pose, t::Real) = a * interp(a ⦸ b, t)
 
 function quatPow(q::UnitQuaternion, t::Real)
   # TODO: Once https://github.com/JuliaGeometry/Rotations.jl/issues/126 is
-  # fixed, this special case won't be necessary
-  if t == 0 || q == one(UnitQuaternion) || q == -one(UnitQuaternion)
+  # fixed, this special case won't be necessary.
+  #
+  # For an example showing why we need an approximately-equal check rather than an exact equality check, see
+  # https://github.com/probcomp/PoseComposition.jl/issues/5
+  ε = 1e-30
+  if (isapprox(t, 0; atol=ε)
+      || isapprox(q, one(UnitQuaternion); atol=ε)
+      || isapprox(q, -one(UnitQuaternion); atol=ε))
     return one(UnitQuaternion)
   end
   return exp(t * log(q))


### PR DESCRIPTION
Fixes https://github.com/probcomp/PoseComposition.jl/issues/5.

## Tested
Confirmed that the example in https://github.com/probcomp/PoseComposition.jl/issues/5#issue-1052386723 is now working on the EC2 instance where it previously failed.  And, unit tests still pass locally.  However, CI is now [failing](https://app.travis-ci.com/github/probcomp/PoseComposition.jl/jobs/547954408#L254), probably again due to system-dependent numerics.  _~~Will fix before merging.~~_  Will try to fix the Travis issue before tagging a new release that includes this PR.