### PR TITLE
Explicitly cast `exp(log(q))` to a `RotationMatrix{3}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "1.5"
 DocStringExtensions = "0.8.5"
 Rotations = "1.0"
 StaticArrays = "1.0"
+julia = "1.5"

--- a/src/PoseComposition.jl
+++ b/src/PoseComposition.jl
@@ -2,7 +2,7 @@ module PoseComposition
 
 import Base: @kwdef
 import LinearAlgebra: dot, norm, cross
-import Rotations: AngleAxis, Rotation, UnitQuaternion, RotZYX
+import Rotations: AngleAxis, Rotation, UnitQuaternion, RotZYX, RotMatrix
 import StaticArrays: StaticVector, SVector, @SVector
 
 include("docstring_extensions.jl")
@@ -298,7 +298,7 @@ function quatPow(q::UnitQuaternion, t::Real)
   if t == 0 || q == one(UnitQuaternion) || q == -one(UnitQuaternion)
     return one(UnitQuaternion)
   end
-  return exp(t * log(q))
+  return RotMatrix{3}(exp(t * log(q)))
 end
 
 


### PR DESCRIPTION
Workaround for https://github.com/JuliaGeometry/Rotations.jl/issues/198

## Tested
CI passes, which it [didn't](https://app.travis-ci.com/github/probcomp/PoseComposition.jl/jobs/547954408#L254) before.