### PR TITLE
Update Rotations.jl, and migrate from now-deprecated `UnitQuaternion` to `QuatRotation`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -74,7 +74,7 @@ places particular emphasis on:
 Define `p1`, the pose of a batter (relative to some arbitrary world coordinate
 frame) in a game of baseball:
 ```julia
-p1 = Pose([10, 10, 0], UnitQuaternion(1, 0, 0, 0))
+p1 = Pose([10, 10, 0], QuatRotation(1, 0, 0, 0))
 ```
 Define `p1_2`, the relative pose of the baseball in the batter's coordinate
 frame, and compute `p2`, the pose of the baseball in the world coordinate

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -30,7 +30,7 @@ rather than written as function applications on the left.
 
 [^1]:
     In code, elements of ``G`` whose orientation is represented as a
-    `Rotations.UnitQuaternion` (as opposed to some other subtype of
+    `Rotations.QuatRotation` (as opposed to some other subtype of
     `Rotations.Rotation{3}`) remember their sign (`q` and `-q` are considered
     equal by `Base.:==`, but their fields are not equal).
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,12 @@
 import PoseComposition: Pose, IDENTITY_POSE, IDENTITY_ORN, interp, ⊗, ⊘
-import Rotations: UnitQuaternion, RotZYX
+import Rotations: QuatRotation, RotZYX
 import StaticArrays: SVector, @SVector
 import Test: @test, @testset
 
 @testset "Pose group operations" begin
-  p1 = Pose(1.0, 1.1, 1.2, UnitQuaternion(√(0.1), √(0.2), √(0.3), √(0.4)))
-  p2 = Pose(2.0, 2.1, 2.2, UnitQuaternion(√(0.2), √(0.2), √(0.3), √(0.3)))
-  p3 = Pose(3.0, 3.1, 3.2, UnitQuaternion(√(0.3), √(0.3), √(0.3), √(0.1)))
+  p1 = Pose(1.0, 1.1, 1.2, QuatRotation(√(0.1), √(0.2), √(0.3), √(0.4)))
+  p2 = Pose(2.0, 2.1, 2.2, QuatRotation(√(0.2), √(0.2), √(0.3), √(0.3)))
+  p3 = Pose(3.0, 3.1, 3.2, QuatRotation(√(0.3), √(0.3), √(0.3), √(0.1)))
 
   function testPosesApprox(a, b; kwargs...)
     @test isapprox(a.pos, b.pos; kwargs...)


### PR DESCRIPTION
## Summary

As titled.

There is a [slight](https://github.com/JuliaGeometry/Rotations.jl/issues/208) backwards-incompatibility, which I think only affects this package in that the field names in `componentsWXYZ` had to be updated.

## Tested

Unit tests still pass.