### PR TITLE
New field names - missed a spot

### DIFF
--- a/src/PoseComposition.jl
+++ b/src/PoseComposition.jl
@@ -81,7 +81,8 @@ end
 
 function strWithQuat(pose::Pose)::String
   q = QuatRotation(pose.orientation)
-  "Pose⟨pos=$(pose.pos), orientation=(w=$(q.q.s), x=$(q.q.v1), y=$(q.q.v2), z=$(q.q.v3))⟩"
+  (w, x, y, z) = componentsWXYZ(q)
+  "Pose⟨pos=$(pose.pos), orientation=(w=$w, x=$x, y=$y, z=$z)⟩"
 end
 
 

--- a/src/PoseComposition.jl
+++ b/src/PoseComposition.jl
@@ -81,7 +81,7 @@ end
 
 function strWithQuat(pose::Pose)::String
   q = QuatRotation(pose.orientation)
-  "Pose⟨pos=$(pose.pos), orientation=(w=$(q.w), x=$(q.x), y=$(q.y), z=$(q.z))⟩"
+  "Pose⟨pos=$(pose.pos), orientation=(w=$(q.q.s), x=$(q.q.v1), y=$(q.q.v2), z=$(q.q.v3))⟩"
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,3 +88,11 @@ end
   @test interp(b, 2) ≈ b ⊗ b
   @test interp(b, 0.5) ⊗ interp(b, 0.5) ≈ b
 end
+
+# Regression test for https://github.com/probcomp/PoseComposition.jl/issues/11
+@testset "Can stringify, print and `show` with no crash" begin
+    pose = Pose([1, 2, 3], RotZYX(0.4, 0.5, 0.6))
+    string(pose)
+    print(devnull, pose)
+    show(devnull, "text/plain", pose)
+end


### PR DESCRIPTION
## Summary
Fixes https://github.com/probcomp/PoseComposition.jl/issues/11 by using the accessor method `componentsWXYZ` rather than referring directly to the underlying field names of a `Rotations.QuatRotation`.

## Tested
Added a unit test that failed (crashed) before the change and passes with the change.  The other unit tests still pass.